### PR TITLE
Get featured news sorting order fix

### DIFF
--- a/news/news_get.go
+++ b/news/news_get.go
@@ -26,7 +26,9 @@ func (r *repository) GetNews(ctx context.Context, newsType Type, language string
 								  AND nvu.user_id = $1
 						WHERE n.language = $2
 							  AND n.type = $3
-						ORDER BY nvu.created_at IS NULL DESC, n.created_at DESC
+						ORDER BY 
+							(CASE WHEN n.type = 'regular' THEN nvu.created_at IS NULL END) DESC,
+							n.created_at DESC
 						LIMIT $4 OFFSET $5`
 	result, err := storage.Select[PersonalNews](ctx, r.db, sql, args...)
 	if err != nil {

--- a/news/news_get.go
+++ b/news/news_get.go
@@ -27,7 +27,10 @@ func (r *repository) GetNews(ctx context.Context, newsType Type, language string
 						WHERE n.language = $2
 							  AND n.type = $3
 						ORDER BY 
-							(CASE WHEN n.type = 'regular' THEN nvu.created_at IS NULL END) DESC,
+							(CASE WHEN n.type = 'regular'
+								THEN nvu.created_at IS NULL
+								ELSE FALSE
+					  		END) DESC,
 							n.created_at DESC
 						LIMIT $4 OFFSET $5`
 	result, err := storage.Select[PersonalNews](ctx, r.db, sql, args...)


### PR DESCRIPTION
Different logic for featured news order by: they are sorted by news.created_at DESC only.