### PR TITLE
fix referral notification when referral is acquired using install referrer

### DIFF
--- a/notifications/notification_type_new_referral.go
+++ b/notifications/notification_type_new_referral.go
@@ -20,11 +20,14 @@ func (r *repository) sendNewReferralNotification(ctx context.Context, us *users.
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "unexpected deadline")
 	}
+	usernameEmpty := us.Username == "" || us.Username == us.ID
+	referredByNotChanged := us.Before != nil && us.Before.ID != "" && us.User != nil && us.User.ID != "" && us.User.ReferredBy == us.Before.ReferredBy
 	if us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID ||
-		(us.Before != nil && us.Before.ID != "" && us.User != nil && us.User.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) ||
-		us.Username == "" || us.Username == us.ID {
+		(referredByNotChanged && !usernameEmpty && !(us.Before.Username == "" || us.Before.Username == us.Before.ID)) ||
+		usernameEmpty {
 		return nil
 	}
+
 	const (
 		actionName = "referral_joined_team"
 	)


### PR DESCRIPTION
When user is created with provided referredBy on creation step it has no user name, and so it does not process notification due to umpty username check.

On further updates user's referredBy and before.referredBy are the same, so notification is not processed at all.

Using this PR we postpone notification to the moment when newly acquired referral gets the username (for 1st time) and then process it.